### PR TITLE
fix: super-linter v6

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Super-linter
         uses: super-linter/super-linter@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,7 @@ jobs:
         env:
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_JSCPD: false
+          VALIDATE_CHECKOV: false
           VALIDATE_RUST_2015: false
           VALIDATE_HTML: false
           DEFAULT_BRANCH: main


### PR DESCRIPTION
super-linter needs the full git history to get the list of files that changed across commits